### PR TITLE
Fixbug when multiple valid links are defined in description

### DIFF
--- a/scripts/github-check-pr-name-and-link.user.js
+++ b/scripts/github-check-pr-name-and-link.user.js
@@ -128,7 +128,7 @@
                 let branchMatch = branchNameRegex.exec(headRef);
                 let branchId = branchMatch[2];
 
-                if (nameId !== branchId || linkId !== branchId) {
+                if (nameId !== branchId || ($.inArray(branchId, linkIds) === -1)) {
                     forbiddenMessage = '<p><strong style="color: #f44;">IDs in PR\'s name, branch and link</strong> are not synced</p>';
                 }
             }

--- a/scripts/github-check-pr-name-and-link.user.js
+++ b/scripts/github-check-pr-name-and-link.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GitHub check PR name and link
 // @namespace    http://tampermonkey.net/
-// @version      1.7
+// @version      1.8
 // @description  Controls if the PR have a valid link in description, a normalized name and a normalized branch name
 // @icon         https://github.githubassets.com/pinned-octocat.svg
 // @author       Cyprille Chauvry


### PR DESCRIPTION
This PR is linked to an issue encountered by @babeuloula.

When browsing a GitHub Pull Request with multiple links in description, data were incorrectly parsed.
This PR is correcting this issue.